### PR TITLE
Return exit code 0 if compare() found anything

### DIFF
--- a/frappuccino/__init__.py
+++ b/frappuccino/__init__.py
@@ -441,6 +441,9 @@ def main():
                     continue
                 print(f"    - {k}.{o}")
 
+        if any([new_keys, removed_keys, changed_keys]):
+            sys.exit(1)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Should enable CI to :x: via returning exit code 1

```
(frap) mwt@mwt-VirtualBox:~/software/frappuccino$ frappuccino openforcefield.typing.engines.smirnoff openforcefield.topology openforcefield.utils --compare out.json 
Collected (Object founds): 363
Visited (don't start with _, not in stdlib...): 910
Rejected (Unknown nodes, or instances, don't know what to do with those): 377

The following items are new:
    + openforcefield.typing.engines.smirnoff.parameters.DuplicateParameterError
    + openforcefield.utils.toolkits.ToolkitRegistry.deregister_toolkit(self, toolkit_wrapper)
    + openforcefield.utils.toolkits.inspect (reexport of inspect)

The following signatures differ between versions:

    - openforcefield.typing.engines.smirnoff.parameters.ParameterHandler.add_parameter(self, parameter_kwargs)
    + openforcefield.typing.engines.smirnoff.parameters.ParameterHandler.add_parameter(self, parameter_kwargs='None', parameter='None', after='None', before='None')

The following attribute seem new, but we are not too sure,
(They might be new inherited attributes, or stuff we don't handle yet)

    + openforcefield.typing.engines.smirnoff.forcefield.ForceField.registered_parameter_handlers
    + openforcefield.utils.toolkits.ToolkitRegistry.deregister_toolkit

The following attribute seem to have been removed:
(They might have been inherited attributes, or stuff we didn't handle then)

(frap) mwt@mwt-VirtualBox:~/software/frappuccino$ echo $?
1
```